### PR TITLE
Added no-private and no-permutation flags

### DIFF
--- a/bin/bucket_crawler
+++ b/bin/bucket_crawler
@@ -22,6 +22,21 @@ def with_mutex
   MUTEX.synchronize { yield }
 end
 
+options = {}
+optparse = OptionParser.new do|opts|
+  # Set a banner, displayed at the top
+  # of the help screen.
+  opts.banner = "Usage: ruby bucket_crawler [options]"
+
+  # Define the options, and what they do
+  options[:showprivate] = true
+  opts.on( '--no-private', 'Suppress printing of private buckets' ) do
+    options[:showprivate] = false
+  end
+end
+
+optparse.parse!
+
 buckets = Bucket.where(:public => true, :crawled_at => nil)
 
 if buckets.count.zero?
@@ -56,7 +71,9 @@ buckets.each do |bucket|
               with_mutex { puts "│   ├──  " + "PUBLIC: #{object.url.bold} (#{Util.number_to_human_size(object.size)})".green }
             else
               object.public = false
-              with_mutex { puts "│   ├── " + "PRIVATE: #{object.url.bold} (#{Util.number_to_human_size(object.size)})".yellow }
+              if options[:showprivate]
+                with_mutex { puts "│   ├── " + "PRIVATE: #{object.url.bold} (#{Util.number_to_human_size(object.size)})".yellow }
+              end
             end
             object.save
           end

--- a/bin/bucket_finder
+++ b/bin/bucket_finder
@@ -20,10 +20,12 @@ class Wordlist
       word.strip!
       next if word.empty?
       yield word
-      PERMUTATION_PATTERNS.each do |permutation_pattern|
-        PERMUTATION_WORDS.each do |permutation_word|
-          yield format(permutation_pattern, word, permutation_word)
-          yield format(permutation_pattern, permutation_word, word)
+      if @options[:permutations]
+	    PERMUTATION_PATTERNS.each do |permutation_pattern|
+	      PERMUTATION_WORDS.each do |permutation_word|
+	        yield format(permutation_pattern, word, permutation_word)
+	        yield format(permutation_pattern, permutation_word, word)
+	      end
         end
       end
     end
@@ -104,9 +106,31 @@ def with_mutex
 end
 
 if ARGV.empty?
-  puts "USAGE: #{0} WORDLIST"
+  puts "USAGE: #{0} [options] WORDLIST"
   exit 1
 end
+
+options = {}
+optparse = OptionParser.new do|opts|
+  # Set a banner, displayed at the top
+  # of the help screen.
+  opts.banner = "USAGE: #{0} [options] WORDLIST"
+
+  # Define the options, and what they do
+  options[:showprivate] = true
+  opts.on( '--no-private', 'Suppress printing of private buckets' ) do
+    options[:showprivate] = false
+  end
+
+  options[:permutations] = true
+  opts.on( '--no-perm', 'Don\'t permute the wordlist' ) do
+    options[:permutations] = false
+  end
+end
+
+#parse and remove from ARGV
+optparse.parse!
+
 
 wordlist    = Wordlist.new(ARGV.first)
 thread_pool = Thread.pool(THREADS)
@@ -119,7 +143,7 @@ wordlist.run do |bucket_name|
         if bucket.exists?
           if bucket.public?
             with_mutex { puts " +  PUBLIC: #{bucket.url.bold}".green }
-          else
+          elsif options[:showprivate]
             with_mutex { puts " - PRIVATE: #{bucket.url.bold}".yellow }
           end
         end

--- a/bootstrap.rb
+++ b/bootstrap.rb
@@ -10,6 +10,7 @@ require "timeout"
 require "sinatra"
 require "colorize"
 require "yaml"
+require "optparse"
 
 CONFIG_FILE_PATH = File.join(File.dirname(__FILE__), "config.yml").freeze
 


### PR DESCRIPTION
Not sure if you're accepting pull requests, but I added a couple minor options that I found useful. Implementation is quick and dirty - happy to change if you have opinions.

Added:

- --no-private flag to bucket_finder and bucket_crawler, suppresses printing of private buckets and objects
- --no-perm flag to bucket_finder, only scans using raw wordlist